### PR TITLE
Podpięcie pod SwaggerUI - model użytkownika

### DIFF
--- a/backend/moj_browarek/urls.py
+++ b/backend/moj_browarek/urls.py
@@ -4,10 +4,11 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework import routers
 
 # imports
-from user.views import UserViewSet
+from user.views import UserViewSet, UserProfileViewSet
 
 router = routers.DefaultRouter()
 router.register(r"users", UserViewSet)
+router.register(r"profiles", UserProfileViewSet)
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/backend/user/serializers.py
+++ b/backend/user/serializers.py
@@ -5,7 +5,7 @@ from .models import UserProfile
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ["id", "username", "email", "first_name", "last_name", "groups"]
+        fields = ["id", "username", "email", "first_name", "last_name"] ## todo add group field in the future
 
 
 class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
@@ -16,3 +16,8 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
         model = UserProfile
         fields = ["user", "weight", "height", "birthDate"]
 
+    def create(self, validated_data):
+        user_data = validated_data.pop("user")
+        user = User.objects.create(**user_data)
+        profile = UserProfile.objects.create(user=user, **validated_data)
+        return profile

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -3,6 +3,8 @@ from rest_framework import permissions, viewsets
 from .serializers import UserSerializer
 from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiExample
 from drf_spectacular.types import OpenApiTypes
+from user.models import UserProfile
+from user.serializers import UserProfileSerializer
 
 
 class UserViewSet(viewsets.ModelViewSet):
@@ -11,4 +13,9 @@ class UserViewSet(viewsets.ModelViewSet):
     """
     queryset = User.objects.all().order_by('-date_joined')
     serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+class UserProfileViewSet(viewsets.ModelViewSet):
+    queryset = UserProfile.objects.all()
+    serializer_class = UserProfileSerializer
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
### Rzeczy zrobione
- Dodanie customowej metody `create` do Serializera dla `UserProfile` (`ModelViewSet` bazowo nie ogarnia nestowanych pól JSONa)
- Napisanie podstawowego viewseta do profili (`UserProfileViewSet`)
- Podpięcie do routera i swaggera
- testowanie manualne endpointów
### Problemy
 - Musiałem na chwilę usunąć pole `groups` z serializera użytkownika (`UserSerializer`) ze względu na problemy z hiperłączami (?) (Nie jestem pewien, ale chyba wymaga to endpointu do grup) jest to pole opcjonalne więc póki co nie jest potrzebne i nie wpływa na działanie aplikacji.

### Testy
#### Test POST
![image](https://github.com/knmlprz/My_browarek/assets/26627330/665c0d59-42f1-4e7b-9312-1c52f3458325)

#### Test GET
![image](https://github.com/knmlprz/My_browarek/assets/26627330/15533254-1e40-41b4-907c-77607dac4a82)

